### PR TITLE
Add transaction_with for transaction multiple models related

### DIFF
--- a/spec/models.rb
+++ b/spec/models.rb
@@ -2,6 +2,9 @@ SwitchPoint.configure do |config|
   config.define_switch_point :main,
     readonly: :main_readonly,
     writable: :main_writable
+  config.define_switch_point :main2,
+    readonly: :main2_readonly,
+    writable: :main2_writable
   config.define_switch_point :user,
     readonly: :user,
     writable: :user
@@ -29,6 +32,14 @@ class Book < ActiveRecord::Base
 
   def do_after_save
   end
+end
+
+class Book2 < ActiveRecord::Base
+  use_switch_point :main
+end
+
+class Book3 < ActiveRecord::Base
+  use_switch_point :main2
 end
 
 class Publisher < ActiveRecord::Base
@@ -66,6 +77,8 @@ base = { adapter: 'sqlite3' }
 ActiveRecord::Base.configurations = {
   'main_readonly' => base.merge(database: 'main_readonly.sqlite3'),
   'main_writable' => base.merge(database: 'main_writable.sqlite3'),
+  'main2_readonly' => base.merge(database: 'main2_readonly.sqlite3'),
+  'main2_writable' => base.merge(database: 'main2_writable.sqlite3'),
   'main_readonly_special' => base.merge(database: 'main_readonly_special.sqlite3'),
   'user' => base.merge(database: 'user.sqlite3'),
   'comment_readonly' => base.merge(database: 'comment_readonly.sqlite3'),

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,18 @@ RSpec.configure do |config|
     Book.with_writable do
       Book.connection.execute('CREATE TABLE books (id integer primary key autoincrement)')
     end
+
+    Book2.with_writable do
+      Book2.connection.execute('CREATE TABLE book2s (id integer primary key autoincrement)')
+    end
+
     FileUtils.cp('main_writable.sqlite3', 'main_readonly.sqlite3')
+
+    Book3.with_writable do
+      Book3.connection.execute('CREATE TABLE book3s (id integer primary key autoincrement)')
+    end
+
+    FileUtils.cp('main2_writable.sqlite3', 'main2_readonly.sqlite3')
 
     Note.connection.execute('CREATE TABLE notes (id integer primary key autoincrement)')
 


### PR DESCRIPTION
This feature supports transaction using multi models.
Using multi models in a transaction...

``` ruby
class Book1 < ActiveRecord::Base
  use_switch_point :db1
end

class Book2 < ActiveRecord::Base
  use_switch_point :db1
end

transaction do
  Book1.with_writable do
    #insert, update, delete, etc...
  end

  Book2.with_writable do
    #insert, update, delete, etc...
  end
end
```

It is not "DRY".

In this case, Book1 and Book2 has a same db connection.
Therefore, we do not need that write twice a "with_writable".

When we write code like this, we must think that switch "readable, writable".

And, transaction must need a same connection.

Now, using this patch...

``` ruby
Book1.transaction_with(Book2) do
  #insert, update, delete, etc...
end
```

It is "DRY" and easier to understand the intention.

Also, user does not run of unintended query to DB.
(ex. User did not know Book2 using other DB.)

It will raise a exception in that case.

``` ruby
class Book3 < ActiveRecord::Base
  use_switch_point :db2
end

Book1.transaction_with(Book2, Book3) do
  #insert, update, delete, etc...
end

#=> raise RuntimeError
```

But, this method is declarative.
You can switch a connection in a block of transaction_with.
