### PR TITLE
Fix Rspec3.3 deprecate warning

### DIFF
--- a/spec/switch_point/model_spec.rb
+++ b/spec/switch_point/model_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe SwitchPoint::Model do
 
   describe '#with_mode' do
     it 'raises error if unknown mode is given' do
-      expect { SwitchPoint::ProxyRepository.checkout(:main).with_mode(:typo) }.to raise_error
+      expect { SwitchPoint::ProxyRepository.checkout(:main).with_mode(:typo) }.to raise_error(ArgumentError)
     end
   end
 


### PR DESCRIPTION
Fix Rspec3.3 Deprecate warning.

```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives,
 since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. 
Instead consider providing a specific error class or message. 
This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /home/nishio/opensource/switch_point/spec/switch_point/model_spec.rb:266:in `block (3 levels) in <top (required)>'.
```