### PR TITLE
Remove alias_method_chain usage

### DIFF
--- a/lib/switch_point.rb
+++ b/lib/switch_point.rb
@@ -66,9 +66,6 @@ ActiveSupport.on_load(:active_record) do
 
   ActiveRecord::Base.send(:include, SwitchPoint::Model)
   ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
-    include SwitchPoint::Connection
-    SwitchPoint::Connection::DESTRUCTIVE_METHODS.each do |method_name|
-      alias_method_chain method_name, :switch_point
-    end
+    prepend SwitchPoint::Connection
   end
 end

--- a/lib/switch_point/model.rb
+++ b/lib/switch_point/model.rb
@@ -6,37 +6,11 @@ module SwitchPoint
     def self.included(model)
       model.singleton_class.class_eval do
         include ClassMethods
-        alias_method_chain :connection, :switch_point
-        alias_method_chain :cache, :switch_point
-        alias_method_chain :uncached, :switch_point
+        prepend MonkeyPatch
       end
     end
 
     module ClassMethods
-      def connection_with_switch_point
-        if switch_point_proxy
-          switch_point_proxy.connection
-        else
-          connection_without_switch_point
-        end
-      end
-
-      def cache_with_switch_point(&block)
-        if switch_point_proxy
-          switch_point_proxy.cache(&block)
-        else
-          cache_without_switch_point(&block)
-        end
-      end
-
-      def uncached_with_switch_point(&block)
-        if switch_point_proxy
-          switch_point_proxy.uncached(&block)
-        else
-          uncached_without_switch_point(&block)
-        end
-      end
-
       def with_readonly(&block)
         if switch_point_proxy
           switch_point_proxy.with_readonly(&block)
@@ -95,6 +69,32 @@ module SwitchPoint
         end
 
         writable_switch_points.uniq.size == 1
+      end
+    end
+
+    module MonkeyPatch
+      def connection
+        if switch_point_proxy
+          switch_point_proxy.connection
+        else
+          super
+        end
+      end
+
+      def cache(&block)
+        if switch_point_proxy
+          switch_point_proxy.cache(&block)
+        else
+          super
+        end
+      end
+
+      def uncached(&block)
+        if switch_point_proxy
+          switch_point_proxy.uncached(&block)
+        else
+          super
+        end
       end
     end
   end


### PR DESCRIPTION
It's marked as deprecated in Rails 5.0.