### PR TITLE
Require Ruby 2.2 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.10
   - 2.2.5
   - 2.3.1
   - jruby-9.1.0.0
@@ -25,9 +24,3 @@ matrix:
     # https://github.com/jruby/activerecord-jdbc-adapter/labels/rails-5.x
     - rvm: jruby-9.1.0.0
       gemfile: gemfiles/rails_5.0.gemfile
-  exclude:
-    # Rails 5 requires to run on Ruby 2.2.0 or newer.
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_5.0.gemfile
-    - rvm: 2.1.10
-      gemfile: gemfiles/rails_edge.gemfile

--- a/switch_point.gemspec
+++ b/switch_point.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'benchmark-ips'


### PR DESCRIPTION
Ruby 2.1 is no longer maintained except for security bugs.
https://www.ruby-lang.org/en/news/2016/03/30/ruby-2-1-9-released/