### PR TITLE
Fix an issue that does not raise even if has a other writable

### DIFF
--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 3.2.0'
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 4.0.0'
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 4.1.0'
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 4.2.0'
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 gemspec path: '../'

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gem 'activerecord', '~> 5.0.0'
 
 platforms :ruby do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 gemspec path: '../'

--- a/lib/switch_point/model.rb
+++ b/lib/switch_point/model.rb
@@ -48,12 +48,16 @@ module SwitchPoint
       end
 
       def switch_point_proxy
+        ProxyRepository.checkout(switch_point_name) if switch_point_name
+      end
+
+      def switch_point_name
         if defined?(@switch_point_name)
-          ProxyRepository.checkout(@switch_point_name)
+          @switch_point_name
         elsif self == ActiveRecord::Base
           nil
         else
-          superclass.switch_point_proxy
+          superclass.switch_point_name
         end
       end
 
@@ -75,9 +79,9 @@ module SwitchPoint
 
       def can_transaction_with?(*models)
         writable_switch_points = [self, *models].map do |model|
-          if model.instance_variable_defined?(:@switch_point_name)
+          if model.switch_point_name
             SwitchPoint.config.model_name(
-              model.instance_variable_get(:@switch_point_name),
+              model.switch_point_name,
               :writable
             )
           end

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -43,6 +43,22 @@ class Book3 < ActiveRecord::Base
   use_switch_point :main2
 end
 
+class AbstractMain < ActiveRecord::Base
+  use_switch_point :main
+  self.abstract_class = true
+end
+
+class Book4 < AbstractMain
+end
+
+class AbstractMain2 < ActiveRecord::Base
+  use_switch_point :main2
+  self.abstract_class = true
+end
+
+class Book5 < AbstractMain2
+end
+
 class Publisher < ActiveRecord::Base
   use_switch_point :main
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ SimpleCov.formatters = [
 SimpleCov.start do
   add_filter Bundler.bundle_path.to_s
   add_filter File.dirname(__FILE__)
+  add_filter '/spec/'
 end
 
 require 'switch_point'

--- a/spec/switch_point/model_spec.rb
+++ b/spec/switch_point/model_spec.rb
@@ -362,6 +362,13 @@ RSpec.describe SwitchPoint::Model do
             Book3.create
           end
         }.to raise_error(SwitchPoint::Error)
+
+        expect {
+          Book4.transaction_with(Book5) do
+            Book4.create
+            Book5.create
+          end
+        }.to raise_error(SwitchPoint::Error)
       }
     end
 

--- a/switch_point.gemspec
+++ b/switch_point.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0'
-  spec.add_development_dependency 'rubocop', '>= 0.50.0'
+  spec.add_development_dependency 'rubocop', '~> 0.58.0'
   spec.add_development_dependency 'simplecov', '>= 0.9.0'
   spec.add_dependency 'activerecord', '>= 3.2.0'
 end


### PR DESCRIPTION
The `@switch_point_name` returns `nil` in the inherited model.
Therefore, no exception occurs even if you pass a model that has other writable.

This commit resolves the issue by changing to follow the switch_point_name of the super class.